### PR TITLE
Adds header to make valid Liquid requests

### DIFF
--- a/src/main/java/com/hedera/services/exchange/exchanges/AbstractExchange.java
+++ b/src/main/java/com/hedera/services/exchange/exchanges/AbstractExchange.java
@@ -20,7 +20,8 @@ public abstract class AbstractExchange implements Exchange {
 		try {
 			final URL url = new URL(endpoint);
 			final HttpURLConnection con = getConnection(url);
-			if(type.getName() == "com.hedera.services.exchange.exchanges.OkCoin") {
+			con.addRequestProperty("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36");
+			if(type.getName().equals("com.hedera.services.exchange.exchanges.OkCoin")) {
 				con.setRequestProperty("X-CoinAPI-Key", OkCoin.APIKEY);
 			}
 			final T exchange =  OBJECT_MAPPER.readValue(con.getInputStream(), type);

--- a/src/test/java/com/hedera/services/exchange/exchanges/LiquidTestCases.java
+++ b/src/test/java/com/hedera/services/exchange/exchanges/LiquidTestCases.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class LiquidTestCases {
-
+    
     @Test
     public void retrieveLiquidDataTest() throws IOException {
         final String result = "{\"product_type\":\"CurrencyPair\", \"code\":\"CASH\", \"last_traded_price\": 0.0093}";


### PR DESCRIPTION
Liquid requests require a header to be a valid User-Agent. 