### PR TITLE
0145 b clip currante rate if out of bound

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.5</version>
+            <version>2.12.1</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>

--- a/src/main/java/com/hedera/exchange/ERTproc.java
+++ b/src/main/java/com/hedera/exchange/ERTproc.java
@@ -142,12 +142,12 @@ public class ERTproc {
             if(midnightExchangeRate != null) {
                 if(!midnightExchangeRate.getNextRate().isSmallChange(this.bound, nextRate)) {
                     LOGGER.debug(Exchange.EXCHANGE_FILTER, "last midnight value present. Validating the nextRate with {}",
-                            midnightExchangeRate.toJson());
+                            midnightExchangeRate.getNextRate().toJson());
                     nextRate = midnightExchangeRate.getNextRate().clipRate(nextRate, this.bound);
                 }
                 if(!midnightExchangeRate.getCurrentRate().isSmallChange(this.bound, currentExchangeRate)) {
-                    LOGGER.debug(Exchange.EXCHANGE_FILTER, "last midnight value present. Validating the nextRate with {}",
-                            midnightExchangeRate.toJson());
+                    LOGGER.debug(Exchange.EXCHANGE_FILTER, "last midnight value present. Validating the currentRate with {}",
+                            midnightExchangeRate.getCurrentRate().toJson());
                     currentExchangeRate = midnightExchangeRate.getCurrentRate().clipRate(currentExchangeRate, this.bound);
                 }
             } else {

--- a/src/main/java/com/hedera/exchange/ExchangeRateTool.java
+++ b/src/main/java/com/hedera/exchange/ExchangeRateTool.java
@@ -164,7 +164,7 @@ public class ExchangeRateTool {
     private static void updateTransactionFileForNetwork(final String networkName,
             final AccountId operatorId,
             final ExchangeRate exchangeRate,
-            final ExchangeRate midnightRate,
+            final ExchangeRate midnightExchangeRate,
             final Map<String, Map<AccountId, String>> networks) throws Exception {
         LOGGER.info(Exchange.EXCHANGE_FILTER, "Performing File update transaction on network {}",
                 networkName);
@@ -191,7 +191,7 @@ public class ExchangeRateTool {
 
             final ERTAddressBook newAddressBook = HederaNetworkCommunicator.updateExchangeRateFile(
                     exchangeRate,
-                    midnightRate,
+                    midnightExchangeRate,
                     hederaClient,
                     ertParams
             );

--- a/src/main/java/com/hedera/exchange/ExchangeRateTool.java
+++ b/src/main/java/com/hedera/exchange/ExchangeRateTool.java
@@ -126,7 +126,6 @@ public class ExchangeRateTool {
 
         final long frequencyInSeconds = ertParams.getFrequencyInSeconds();
         final ExchangeRate midnightExchangeRate = exchangeDB.getLatestMidnightExchangeRate();
-        final Rate midnightRate = midnightExchangeRate == null ? null : midnightExchangeRate.getNextRate();
         final Rate currentRate = getCurrentRate(exchangeDB, ertParams);
         final AccountId operatorId = AccountId.fromString(ertParams.getOperatorId());
         final ExchangeRateUtils exchangeRateUtils = new ExchangeRateUtils();
@@ -137,7 +136,7 @@ public class ExchangeRateTool {
                 exchanges,
                 ertParams.getBound(),
                 ertParams.getFloor(),
-                midnightRate,
+                midnightExchangeRate,
                 currentRate,
                 frequencyInSeconds);
 
@@ -149,7 +148,7 @@ public class ExchangeRateTool {
                 continue;
             }
 
-            updateTransactionFileForNetwork(networkName, operatorId, exchangeRate, midnightRate, networks);
+            updateTransactionFileForNetwork(networkName, operatorId, exchangeRate, midnightExchangeRate, networks);
         }
 
         exchangeDB.pushExchangeRate(exchangeRate);
@@ -165,7 +164,7 @@ public class ExchangeRateTool {
     private static void updateTransactionFileForNetwork(final String networkName,
             final AccountId operatorId,
             final ExchangeRate exchangeRate,
-            final Rate midnightRate,
+            final ExchangeRate midnightRate,
             final Map<String, Map<AccountId, String>> networks) throws Exception {
         LOGGER.info(Exchange.EXCHANGE_FILTER, "Performing File update transaction on network {}",
                 networkName);

--- a/src/main/java/com/hedera/exchange/HederaNetworkCommunicator.java
+++ b/src/main/java/com/hedera/exchange/HederaNetworkCommunicator.java
@@ -93,17 +93,19 @@ public class HederaNetworkCommunicator {
      * @throws InterruptedException
      */
     public static ERTAddressBook updateExchangeRateFile(final ExchangeRate exchangeRate,
-                                                        final Rate midnightRate,
+                                                        final ExchangeRate midnightRate,
                                                         Client client,
                                                         ERTParams ertParams) throws HederaStatusException, TimeoutException, InterruptedException {
 
         final byte[] exchangeRateAsBytes = exchangeRate.toExchangeRateSet().toByteArray();
         final AccountId operatorId = AccountId.fromString(ertParams.getOperatorId());
 
-        final String memo = String.format("currentRate : %d, nextRate : %d, midnightRate : %d",
-                exchangeRate.getCurrentRate().getCentEquiv(),
-                exchangeRate.getNextRate().getCentEquiv(),
-                midnightRate == null ? 0 : midnightRate.getCentEquiv());
+        final String memo = String.format("currentRate : %.4f, nextRate : %.4f, midnight-currentRate : %.4f midnight" +
+                        "-nextRate : %.4f",
+                exchangeRate.getCurrentRate().getRateinUSD(),
+                exchangeRate.getNextRate().getRateinUSD(),
+                midnightRate == null ? 0.0 : midnightRate.getCurrentRate().getRateinUSD(),
+                midnightRate == null ? 0.0 : midnightRate.getNextRate().getRateinUSD());
         LOGGER.info(Exchange.EXCHANGE_FILTER, "Memo for the FileUpdate tx : {}", memo);
 
         final FileId exchangeRateFileId = FileId.fromString(ertParams.getFileId());

--- a/src/main/java/com/hedera/exchange/HederaNetworkCommunicator.java
+++ b/src/main/java/com/hedera/exchange/HederaNetworkCommunicator.java
@@ -84,7 +84,7 @@ public class HederaNetworkCommunicator {
     /**
      * Method to send a File update transaction to hedera network and fetch the latest addressBook from the network.
      * @param exchangeRate
-     * @param midnightRate
+     * @param midnightExchangeRate
      * @param client
      * @param ertParams
      * @return Latest AddressBook from the Hedera Network
@@ -93,7 +93,7 @@ public class HederaNetworkCommunicator {
      * @throws InterruptedException
      */
     public static ERTAddressBook updateExchangeRateFile(final ExchangeRate exchangeRate,
-                                                        final ExchangeRate midnightRate,
+                                                        final ExchangeRate midnightExchangeRate,
                                                         Client client,
                                                         ERTParams ertParams) throws HederaStatusException, TimeoutException, InterruptedException {
 
@@ -104,8 +104,8 @@ public class HederaNetworkCommunicator {
                         "-nextRate : %.4f",
                 exchangeRate.getCurrentRate().getRateinUSD(),
                 exchangeRate.getNextRate().getRateinUSD(),
-                midnightRate == null ? 0.0 : midnightRate.getCurrentRate().getRateinUSD(),
-                midnightRate == null ? 0.0 : midnightRate.getNextRate().getRateinUSD());
+                midnightExchangeRate == null ? 0.0 : midnightExchangeRate.getCurrentRate().getRateinUSD(),
+                midnightExchangeRate == null ? 0.0 : midnightExchangeRate.getNextRate().getRateinUSD());
         LOGGER.info(Exchange.EXCHANGE_FILTER, "Memo for the FileUpdate tx : {}", memo);
 
         final FileId exchangeRateFileId = FileId.fromString(ertParams.getFileId());

--- a/src/main/java/com/hedera/exchange/HederaNetworkCommunicator.java
+++ b/src/main/java/com/hedera/exchange/HederaNetworkCommunicator.java
@@ -102,10 +102,10 @@ public class HederaNetworkCommunicator {
 
         final String memo = String.format("currentRate : %.4f, nextRate : %.4f, midnight-currentRate : %.4f midnight" +
                         "-nextRate : %.4f",
-                exchangeRate.getCurrentRate().getRateinUSD(),
-                exchangeRate.getNextRate().getRateinUSD(),
-                midnightExchangeRate == null ? 0.0 : midnightExchangeRate.getCurrentRate().getRateinUSD(),
-                midnightExchangeRate == null ? 0.0 : midnightExchangeRate.getNextRate().getRateinUSD());
+                exchangeRate.getCurrentRate().getRateInUSD(),
+                exchangeRate.getNextRate().getRateInUSD(),
+                midnightExchangeRate == null ? 0.0 : midnightExchangeRate.getCurrentRate().getRateInUSD(),
+                midnightExchangeRate == null ? 0.0 : midnightExchangeRate.getNextRate().getRateInUSD());
         LOGGER.info(Exchange.EXCHANGE_FILTER, "Memo for the FileUpdate tx : {}", memo);
 
         final FileId exchangeRateFileId = FileId.fromString(ertParams.getFileId());

--- a/src/main/java/com/hedera/exchange/Rate.java
+++ b/src/main/java/com/hedera/exchange/Rate.java
@@ -250,6 +250,10 @@ public class Rate {
         return OBJECT_MAPPER.writeValueAsString(this);
     }
 
+    @JsonIgnore
+    /**
+     * Get the hbar rate in USD
+     */
     public double getRateinUSD() {
         return (double) centEquiv/hbarEquiv;
     }

--- a/src/main/java/com/hedera/exchange/Rate.java
+++ b/src/main/java/com/hedera/exchange/Rate.java
@@ -249,4 +249,8 @@ public class Rate {
     public String toJson() throws JsonProcessingException {
         return OBJECT_MAPPER.writeValueAsString(this);
     }
+
+    public double getRateinUSD() {
+        return (double) centEquiv/hbarEquiv;
+    }
 }

--- a/src/main/java/com/hedera/exchange/Rate.java
+++ b/src/main/java/com/hedera/exchange/Rate.java
@@ -255,6 +255,6 @@ public class Rate {
      * Get the hbar rate in USD
      */
     public double getRateinUSD() {
-        return (double) centEquiv/hbarEquiv;
+        return ((double) centEquiv/hbarEquiv) / 100;
     }
 }

--- a/src/main/java/com/hedera/exchange/Rate.java
+++ b/src/main/java/com/hedera/exchange/Rate.java
@@ -254,7 +254,7 @@ public class Rate {
     /**
      * Get the hbar rate in USD
      */
-    public double getRateinUSD() {
+    public double getRateInUSD() {
         return ((double) centEquiv/hbarEquiv) / 100;
     }
 }

--- a/src/test/java/com/hedera/exchange/ERTprocTestCases.java
+++ b/src/test/java/com/hedera/exchange/ERTprocTestCases.java
@@ -86,7 +86,7 @@ public class ERTprocTestCases {
                 exchanges,
                 params.getBound(),
                 params.getFloor(),
-                params.getDefaultRate(),
+                new ExchangeRate(params.getDefaultRate(), params.getDefaultRate()),
                 params.getDefaultRate(),
                 params.getFrequencyInSeconds());
         final ExchangeRate exchangeRate = ertProcess.call();
@@ -157,7 +157,7 @@ public class ERTprocTestCases {
                 justBitrexExchange,
                 params.getBound(),
                 params.getFloor(),
-                currentRate,
+                new ExchangeRate(currentRate, currentRate),
                 currentRate,
                 params.getFrequencyInSeconds());
 
@@ -191,7 +191,7 @@ public class ERTprocTestCases {
                 exchanges,
                 params.getBound(),
                 params.getFloor(),
-                midnightRate,
+                new ExchangeRate(midnightRate,midnightRate),
                 currentRate,
                 params.getFrequencyInSeconds());
         final ExchangeRate exchangeRate = ertProcess.call();

--- a/src/test/java/com/hedera/exchange/RateTestCases.java
+++ b/src/test/java/com/hedera/exchange/RateTestCases.java
@@ -53,6 +53,8 @@ package com.hedera.exchange;
  */
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -118,5 +120,18 @@ public class RateTestCases {
 		Rate clippedRate = midnightRate.clipRate(nextRate, bound);
 
 		assertEquals(true, midnightRate.isSmallChange(bound, clippedRate));
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"120000,0.04",
+			"300000,0.10",
+			"225000,0.075",
+			"3900000,1.30",
+			"15462000,5.154"
+	})
+	public void testUSDconversion(long centEquiv, double usd) {
+		Rate rate = new Rate(30000, centEquiv, 1568592000);
+		assertEquals(usd, rate.getRateinUSD());
 	}
 }

--- a/src/test/java/com/hedera/exchange/RateTestCases.java
+++ b/src/test/java/com/hedera/exchange/RateTestCases.java
@@ -132,6 +132,6 @@ public class RateTestCases {
 	})
 	public void testUSDconversion(long centEquiv, double usd) {
 		Rate rate = new Rate(30000, centEquiv, 1568592000);
-		assertEquals(usd, rate.getRateinUSD());
+		assertEquals(usd, rate.getRateInUSD());
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<summary>`
-->

**Related issue(s)**:
Closes #144 #145 #148 

**Summary of the change**:
We are now comparing currentRate as well with the `currentRate` in `midnightRate` and check if is in bound. 
If not we are clipping it as well.

Updated memo field to show the rate in `USD` instead.

Updated `jackson-databind` dependency to the latest version from maven.


**Applicable documentation**
- [x] Javadoc
- [x] tests
- [x] README
