### PR TITLE
Add region as a new configurable parameter

### DIFF
--- a/src/main/java/com/hedera/exchange/ERTParams.java
+++ b/src/main/java/com/hedera/exchange/ERTParams.java
@@ -133,6 +133,9 @@ public class ERTParams {
     @JsonProperty("validationDelayInMilliseconds")
     private int validationDelayInMilliseconds;
 
+    @JsonProperty("region")
+    private String region;
+
     /**
      * Return a ERTParams class populated with the configuration parameters read from the config file.
      * The reading method depends on the argument/config file path passed in the call.
@@ -426,5 +429,13 @@ public class ERTParams {
      */
     public ExchangeDB getExchangeDB() {
         return new ExchangeRateAWSRD(new AWSDBParams());
+    }
+
+    /**
+     * Get the region in which this lambda is configured to be deployed in
+     * @return
+     */
+    public String getRegion() {
+        return this.region;
     }
 }

--- a/src/main/java/com/hedera/exchange/ERTProcessLogic.java
+++ b/src/main/java/com/hedera/exchange/ERTProcessLogic.java
@@ -86,6 +86,7 @@ public class ERTProcessLogic {
     private Rate currentExchangeRate;
     private final long hbarEquiv;
     private final long frequencyInSeconds;
+    private final String region;
 
     public ERTProcessLogic(final long hbarEquiv,
             final List<Exchange> exchanges,
@@ -93,7 +94,8 @@ public class ERTProcessLogic {
             final long floor,
             final ExchangeRate midnightExchangeRate,
             final Rate currentExchangeRate,
-            final long frequencyInSeconds) {
+            final long frequencyInSeconds,
+            final String region) {
         this.hbarEquiv = hbarEquiv;
         this.exchanges = exchanges;
         this.bound = bound;
@@ -101,6 +103,7 @@ public class ERTProcessLogic {
         this.midnightExchangeRate = midnightExchangeRate;
         this.currentExchangeRate = currentExchangeRate;
         this.frequencyInSeconds = frequencyInSeconds;
+        this.region = region;
     }
 
     /**
@@ -143,6 +146,11 @@ public class ERTProcessLogic {
                     LOGGER.debug(Exchange.EXCHANGE_FILTER, "last midnight value present. Validating the nextRate with {}",
                             midnightExchangeRate.getNextRate().toJson());
                     nextRate = midnightExchangeRate.getNextRate().clipRate(nextRate, this.bound);
+                } else {
+                    String message = String.format("WARNING : Calculated median %s is Invalid with Midnight Rate as %s",
+                            nextRate.toJson(), midnightExchangeRate.getNextRate().toJson());
+                    LOGGER.warn(message);
+                    ERTNotificationHelper.publishMessage("WARNING : Calculated Median is Invalid", message, region);
                 }
                 if(!midnightExchangeRate.getCurrentRate().isSmallChange(this.bound, currentExchangeRate)) {
                     LOGGER.debug(Exchange.EXCHANGE_FILTER, "last midnight value present. Validating the currentRate with {}",

--- a/src/main/java/com/hedera/exchange/ExchangeRateTool.java
+++ b/src/main/java/com/hedera/exchange/ExchangeRateTool.java
@@ -109,7 +109,7 @@ public class ExchangeRateTool {
             final var subject = "FAILED : ERT Run Failed";
             final var message = ex.getMessage() + "\n";
             LOGGER.error(Exchange.EXCHANGE_FILTER, subject, ex);
-            ERTNotificationHelper.publishMessage(subject, message + ExceptionUtils.getStackTrace(ex));
+            ERTNotificationHelper.publishMessage(subject, message + ExceptionUtils.getStackTrace(ex), ertParams.getRegion());
         }
     }
 
@@ -128,7 +128,6 @@ public class ExchangeRateTool {
      *          Throws Timeout Exception when unable to complete a Hedera Transaction with in the timeout.
      */
     protected void execute() throws IOException, SQLException, TimeoutException {
-
         final Map<String, Map<String, AccountId>> networks = ertParams.getNetworks();
 
         final long frequencyInSeconds = ertParams.getFrequencyInSeconds();
@@ -145,7 +144,8 @@ public class ExchangeRateTool {
                 ertParams.getFloor(),
                 midnightExchangeRate,
                 currentRate,
-                frequencyInSeconds);
+                frequencyInSeconds,
+                ertParams.getRegion());
 
         final ExchangeRate exchangeRate = proc.call();
 
@@ -169,7 +169,7 @@ public class ExchangeRateTool {
             } else {
                 final var errMessage = String.format("FAILED : The Exchange Rates were not successfully updated on %s",
                         networkName);
-                ERTNotificationHelper.publishMessage(errMessage, errMessage);
+                ERTNotificationHelper.publishMessage(errMessage, errMessage, ertParams.getRegion());
                 LOGGER.error(Exchange.EXCHANGE_FILTER, errMessage);
             }
         }
@@ -207,7 +207,7 @@ public class ExchangeRateTool {
             if (hederaClient == null) {
                 LOGGER.error(Exchange.EXCHANGE_FILTER, "Error while building a Hedera Client");
                 final var subject = String.format("ERROR : Couldn't Build a Hedera Client on %s", networkName);
-                ERTNotificationHelper.publishMessage(subject, "Retrying..");
+                ERTNotificationHelper.publishMessage(subject, "Retrying..", ertParams.getRegion());
                 throw new IllegalStateException(subject);
             }
 

--- a/src/main/java/com/hedera/exchange/HederaNetworkCommunicator.java
+++ b/src/main/java/com/hedera/exchange/HederaNetworkCommunicator.java
@@ -151,7 +151,7 @@ public class HederaNetworkCommunicator {
 
         ERTAddressBook newAddressBook = fetchAddressBook(client);
 
-        updateExchangeRateFileTxn(exchangeRate, exchangeRateFileId, exchangeRateAsBytes, client, memo);
+        updateExchangeRateFileTxn(exchangeRate, exchangeRateFileId, exchangeRateAsBytes, client, memo, ertParams.getRegion());
 
         waitForChangesToTakeEffect(ertParams.getValidationDelayInMilliseconds());
 
@@ -193,7 +193,8 @@ public class HederaNetworkCommunicator {
             final FileId exchangeRateFileId,
             final byte[] exchangeRateAsBytes,
             final Client client,
-            final String memo)
+            final String memo,
+            final String region)
             throws TimeoutException, PrecheckStatusException, IOException, ReceiptStatusException {
         int retryCount = 1;
         TransactionReceipt transactionReceipt;
@@ -239,7 +240,7 @@ public class HederaNetworkCommunicator {
                     LOGGER.info(Exchange.EXCHANGE_FILTER, "Exchange Rates from receipt {}", rateInNetwork);
                     retryMessage = String.format("ERROR : %s \n proposed rate : %s \n Rates on Network %s",
                             retryMessage, proposedRate, rateInNetwork);
-                    ERTNotificationHelper.publishMessage(subject, retryMessage);
+                    ERTNotificationHelper.publishMessage(subject, retryMessage, region);
 
                     Rate activeRate = new Rate(activeRateFromReceipt.hbars,
                             activeRateFromReceipt.cents,
@@ -257,7 +258,7 @@ public class HederaNetworkCommunicator {
             } catch (PrecheckStatusException ex) {
                 var subject = String.format("ERROR : %s : PreCheckStatusException : %s", networkName, ex.status);
                 LOGGER.error(Exchange.EXCHANGE_FILTER, subject);
-                ERTNotificationHelper.publishMessage(subject, ExceptionUtils.getStackTrace(ex));
+                ERTNotificationHelper.publishMessage(subject, ExceptionUtils.getStackTrace(ex), region);
                 if( retryCount++ == DEFAULT_RETRIES ) {
                     throw ex;
                 }

--- a/src/main/java/com/hedera/exchange/Rate.java
+++ b/src/main/java/com/hedera/exchange/Rate.java
@@ -128,17 +128,12 @@ public class Rate {
                 this.getCentEquiv(),
                 this.getHBarEquiv(),
                 nextRate.getCentEquiv(),
-                nextRate.getHBarEquiv())){
+                nextRate.getHBarEquiv())) {
             LOGGER.debug("Calculated median {} is Valid with Midnight Rate as {}",
                     nextRate.toJson(), this.toJson());
             return true;
-        } else {
-            String message = String.format("WARNING : Calculated median %s is Invalid with Midnight Rate as %s",
-                    nextRate.toJson(), this.toJson());
-            LOGGER.warn(message);
-            ERTNotificationHelper.publishMessage("WARNING : Calculated Median is Invalid", message);
-            return false;
         }
+        return false;
     }
 
     /**

--- a/src/main/java/com/hedera/exchange/api/ExchangeRateHistoryAPI.java
+++ b/src/main/java/com/hedera/exchange/api/ExchangeRateHistoryAPI.java
@@ -173,7 +173,7 @@ public class ExchangeRateHistoryAPI implements RequestStreamHandler {
                 double currentMedian = findMedian(currentQueriedRate);
                 results.add(new ExchangeRateHistory(toDate(expirationTime),
                         currentQueriedRate,
-                        calulateMedian(currentExchangeRate),
+                        calculateMedian(currentExchangeRate),
                         isSmoothed(midnightRate.getNextRate(), currentMedian),
                         midnightRate,
                         currentExchangeRate.getCurrentRate(),
@@ -202,7 +202,7 @@ public class ExchangeRateHistoryAPI implements RequestStreamHandler {
         responseWriter.close();
     }
 
-    private static double calulateMedian(ExchangeRate exchangeRate){
+    private static double calculateMedian(ExchangeRate exchangeRate){
         LOGGER.info(Exchange.EXCHANGE_FILTER, "calculating median");
         double median = ((double) exchangeRate.getNextRate().getCentEquiv() / exchangeRate.getNextRate().getHBarEquiv()) / 100 ;
 

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -33,6 +33,7 @@
 			"0.0.3": "35.196.144.134:50211"
 		}
 	},
-	"payerAccount": "0.0.57"
+	"payerAccount": "0.0.57",
+  	"region": "us-east-1"
 }
 

--- a/src/test/java/com/hedera/exchange/ERTProcessLogicTestCases.java
+++ b/src/test/java/com/hedera/exchange/ERTProcessLogicTestCases.java
@@ -113,7 +113,8 @@ public class ERTProcessLogicTestCases {
                 params.getFloor(),
                 new ExchangeRate(params.getDefaultRate(), params.getDefaultRate()),
                 params.getDefaultRate(),
-                params.getFrequencyInSeconds());
+                params.getFrequencyInSeconds(),
+                params.getRegion());
         final ExchangeRate exchangeRate = ertProcess.call();
         final ExchangeRateSet exchangeRateSet = exchangeRate.toExchangeRateSet();
         assertEquals(expectedCentEquiv, exchangeRateSet.getNextRate().getCentEquiv());
@@ -142,7 +143,8 @@ public class ERTProcessLogicTestCases {
                 params.getFloor(),
                 null,
                 params.getDefaultRate(),
-                params.getFrequencyInSeconds());
+                params.getFrequencyInSeconds(),
+                params.getRegion());
         final ExchangeRate exchangeRate = ertProcess.call();
         final ExchangeRateSet exchangeRateSet = exchangeRate.toExchangeRateSet();
         assertEquals(expectedCentEquiv, exchangeRateSet.getNextRate().getCentEquiv());
@@ -184,7 +186,8 @@ public class ERTProcessLogicTestCases {
                 params.getFloor(),
                 new ExchangeRate(currentRate, currentRate),
                 currentRate,
-                params.getFrequencyInSeconds());
+                params.getFrequencyInSeconds(),
+                params.getRegion());
 
         final ExchangeRate exchangeRate = ertProcess.call();
 
@@ -218,7 +221,8 @@ public class ERTProcessLogicTestCases {
                 params.getFloor(),
                 new ExchangeRate(midnightRate,midnightRate),
                 currentRate,
-                params.getFrequencyInSeconds());
+                params.getFrequencyInSeconds(),
+                params.getRegion());
         final ExchangeRate exchangeRate = ertProcess.call();
         final ExchangeRateSet exchangeRateSet = exchangeRate.toExchangeRateSet();
         assertEquals(expectedCentEquiv, exchangeRateSet.getNextRate().getCentEquiv());
@@ -243,7 +247,8 @@ public class ERTProcessLogicTestCases {
                 params.getFloor(),
                 null,
                 null,
-                params.getFrequencyInSeconds()
+                params.getFrequencyInSeconds(),
+                params.getRegion()
         );
 
         assertEquals(1.0, ertProcess.findVolumeWeightedMedian(

--- a/src/test/resources/configs/config.json
+++ b/src/test/resources/configs/config.json
@@ -27,5 +27,6 @@
 	},
 	"payerAccount": "0.0.57",
 	"fileId": "0.0.112",
-  	"validationDelayInMilliseconds": 15000
+  	"validationDelayInMilliseconds": 15000,
+  	"region": "us-east-1"
 }

--- a/src/test/resources/configs/config1.json
+++ b/src/test/resources/configs/config1.json
@@ -16,5 +16,6 @@
     "0.0.5": "1.testnet.hedera.com:71322"
   },
   "payerAccount": "0.0.57",
-  "validationDelayInMilliseconds": 15000
+  "validationDelayInMilliseconds": 15000,
+  "region": "us-east-2"
 }

--- a/src/test/resources/configs/config2.json
+++ b/src/test/resources/configs/config2.json
@@ -16,5 +16,6 @@
     "0.0.5": "1.testnet.hedera.com:71322"
   },
   "payerAccount": "0.0.57",
-  "validationDelayInMilliseconds": 15000
+  "validationDelayInMilliseconds": 15000,
+  "region": "us-east-2"
 }

--- a/src/test/resources/configs/configSimple.json
+++ b/src/test/resources/configs/configSimple.json
@@ -20,5 +20,6 @@
 	},
 	"payerAccount": "0.0.57",
 	"fileId": "0.0.112",
-  	"validationDelayInMilliseconds": 15000
+  	"validationDelayInMilliseconds": 15000,
+  	"region": "us-east-1"
 }


### PR DESCRIPTION
Signed-off-by: anighanta <anirudh.ghanta@hedera.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<summary>`
-->

**Related issue(s)**:
Closes #182 

**Summary of the change**:
Added the AWS region as a configurable parameter to help SNS topics to be accessible from different regions.
Defaulted the region to `us-east-1` if invalid region is provided.

**Applicable documentation**
- [ ] Javadoc
- [ ] tests
- [ ] README
